### PR TITLE
Add prompt engineering guidance from major AI providers

### DIFF
--- a/prompt_engineering/anthropic.md
+++ b/prompt_engineering/anthropic.md
@@ -1,0 +1,15 @@
+# Anthropic Prompt Engineering Guidance
+
+Source: https://docs.anthropic.com/claude/docs/prompt-engineering
+
+Anthropic organizes its prompt engineering techniques from general to advanced. Key recommendations include:
+
+- **Prompt generator** – Use tooling to draft initial prompts.
+- **Be clear and direct** – State instructions plainly to minimize ambiguity.
+- **Use examples (multishot prompting)** – Show Claude how to respond by providing sample interactions.
+- **Let Claude think (chain of thought)** – Encourage step-by-step reasoning before giving the final answer.
+- **Use XML tags** – Mark up sections of the prompt to control scope and improve parsing.
+- **Give Claude a role (system prompts)** – Assign roles or personas to guide style and behavior.
+- **Prefill Claude’s response** – Start the reply to steer format or style.
+- **Chain complex prompts** – Break long requests into linked prompts for more reliable results.
+- **Long context tips** – Manage very long conversations or documents with summarization or filtering.

--- a/prompt_engineering/google.md
+++ b/prompt_engineering/google.md
@@ -1,0 +1,13 @@
+# Google Prompt Engineering Guidance
+
+Source: https://ai.google.dev/gemini-api/docs/prompting
+
+Google's developer documentation for Gemini models emphasizes the following best practices:
+
+- **Give explicit and concise instructions** so the model knows exactly what you want.
+- **Provide context or background information** to ground the response.
+- **Specify the desired output format and length** to control structure and verbosity.
+- **Include examples or templates** to demonstrate ideal responses.
+- **Break complex tasks into steps** and use structured prompts for reliability.
+- **Iterate and refine prompts** based on model outputs to improve quality over time.
+- **Respect safety guidelines** by avoiding sensitive data and reviewing responses.

--- a/prompt_engineering/openai.md
+++ b/prompt_engineering/openai.md
@@ -1,0 +1,12 @@
+# OpenAI Prompt Engineering Guidance
+
+Source: https://platform.openai.com/docs/guides/prompt-engineering
+
+OpenAI highlights six key strategies for getting better results from GPT models:
+
+- **Write clear instructions** – Specify desired format, length, persona, and steps so the model doesn't have to guess.
+- **Provide reference text** – Supply relevant documents to reduce fabrication and improve accuracy.
+- **Split complex tasks into simpler subtasks** – Break problems down and sequence prompts to handle each part.
+- **Give the model time to think** – Encourage reasoning or ask the model to work out solutions before answering.
+- **Use external tools** – Combine the model with search, code execution, or other tools to extend capabilities.
+- **Test changes systematically** – Evaluate prompts against gold‑standard answers and iterate based on results.


### PR DESCRIPTION
## Summary
- document OpenAI's six core strategies for better prompts
- document Anthropic's prompt engineering recommendations for Claude
- document Google's prompt best practices for Gemini

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68badc671dd08322969cd82550d9ff5e