### PR TITLE
Add Amazon SDE II Agentic Marketing job descriptions

### DIFF
--- a/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052297.md
+++ b/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052297.md
@@ -1,0 +1,81 @@
+# Software Engineer II, Agentic Marketing Automation
+
+Job ID: 3052297 | Amazon Development Centre Canada ULC
+URL: https://www.amazon.jobs/en/jobs/3052297/software-engineer-ii-agentic-marketing-automation
+
+**DESCRIPTION**
+
+Are you excited to build the customer-facing experience for Amazon Deals? Do you want to write code
+for highly-visible, scalable systems that serve millions of customers every day? The Deals &
+Promotions team is at the center of Amazon's retail business, and we are on a mission to create a
+world-class deals experience for our customers. We are building the future where AI and automation
+help us discover and present the best offers, and we are looking for passionate engineers to build
+it with us.
+
+As a an SDE on this team, you will be a key contributor to our most critical projects. You will own
+the design, implementation, and deployment of features and services that shape the Amazon Deals
+experience. This is an end-to-end role where you will work on everything from the customer-facing
+user interface to the backend automation services that integrate with AI Agents to bring our
+promotions to life. We are looking for a customer-focused engineer who is comfortable working
+through ambiguity, has a passion for building high-quality, robust software, and enjoys the
+challenge of working at a massive scale.
+
+A day in the life
+
+As a an SDE II, you will work with your team to invent, design, and build software that is used by
+millions of people. You will have a direct impact on our customers and the business. You will be
+responsible for:
+
+- Designing, implementing, testing, and deploying scalable, low-latency services and features for
+  our deals and promotions platform.
+- Working closely with product managers, UX designers, and other engineers to translate customer and
+  business requirements into robust technical solutions.
+- Contributing to the operational excellence of the team's services, participating in on-call
+  rotations, and improving system performance and reliability.
+- Setting a high standard for you and the team by writing clean, maintainable code and participating
+  in code reviews.
+- Mentoring junior engineers and sharing your knowledge to help the team grow stronger.
+
+About the team
+
+Our team's mission is to make the Amazon Deals experience more dynamic, personalized, and efficient
+through intelligent automation. To achieve our vision, we:
+
+- Build and operate the core services that allow AI agents to access critical data like pricing and
+  inventory to construct valid and compelling promotions.
+- Own the customer-facing features and deep instrumentation that allow us to A/B test different
+  agent-driven strategies and measure customer engagement.
+- Ensure every feature we build creates a data flywheel, where customer interactions are used as a
+  signal to improve the intelligence of our automation systems.
+- Work directly with our internal business teams to automate their most time-consuming tasks,
+  freeing them to focus on curating higher-quality deals for customers.
+- Deliver a best-in-class customer experience by building fast, reliable, and intuitive features
+  that help customers discover the best deals Amazon has to offer.
+
+**BASIC QUALIFICATIONS**
+- 3+ years of non-internship professional software development experience
+- 2+ years of non-internship design or architecture (design patterns, reliability and scaling) of
+  new and existing systems experience
+- Experience programming with at least one software programming language
+
+**PREFERRED QUALIFICATIONS**
+- 3+ years of full software development life cycle, including coding standards, code reviews, source
+  control management, build processes, testing, and operations experience
+- Bachelor's degree in computer science or equivalent
+
+Amazon is an equal opportunity employer and does not discriminate on the basis of protected veteran
+status, disability, or other legally protected status.
+
+Our inclusive culture empowers Amazonians to deliver the best results for our customers. If you have
+a disability and need a workplace accommodation or adjustment during the application and hiring
+process, including support for the interview or onboarding process, please visit
+https://amazon.jobs/content/en/how-we-hire/accommodations for more information. If the
+country/region you’re applying in isn’t listed, please contact your Recruiting Partner.
+
+The base salary for this position ranges from $114,800/year up to $191,800/year. Salary is based on
+a number of factors and may vary depending on job-related knowledge, skills, and experience. Amazon
+is a total compensation company. Dependent on the position offered, equity, sign-on payments, and
+other forms of compensation may be provided as part of a total compensation package, in addition to
+a full range of medical, financial, and/or other benefits. Applicants should apply via our internal
+or external career site.
+

--- a/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052298.md
+++ b/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052298.md
@@ -1,0 +1,81 @@
+# Software Engineer II, Agentic Marketing Automation
+
+Job ID: 3052298 | Amazon Development Centre Canada ULC
+URL: https://www.amazon.jobs/en/jobs/3052298/software-engineer-ii-agentic-marketing-automation
+
+**DESCRIPTION**
+
+Are you excited to build the customer-facing experience for Amazon Deals? Do you want to write code
+for highly-visible, scalable systems that serve millions of customers every day? The Deals &
+Promotions team is at the center of Amazon's retail business, and we are on a mission to create a
+world-class deals experience for our customers. We are building the future where AI and automation
+help us discover and present the best offers, and we are looking for passionate engineers to build
+it with us.
+
+As a an SDE on this team, you will be a key contributor to our most critical projects. You will own
+the design, implementation, and deployment of features and services that shape the Amazon Deals
+experience. This is an end-to-end role where you will work on everything from the customer-facing
+user interface to the backend automation services that integrate with AI Agents to bring our
+promotions to life. We are looking for a customer-focused engineer who is comfortable working
+through ambiguity, has a passion for building high-quality, robust software, and enjoys the
+challenge of working at a massive scale.
+
+A day in the life
+
+As a an SDE II, you will work with your team to invent, design, and build software that is used by
+millions of people. You will have a direct impact on our customers and the business. You will be
+responsible for:
+
+- Designing, implementing, testing, and deploying scalable, low-latency services and features for
+  our deals and promotions platform.
+- Working closely with product managers, UX designers, and other engineers to translate customer and
+  business requirements into robust technical solutions.
+- Contributing to the operational excellence of the team's services, participating in on-call
+  rotations, and improving system performance and reliability.
+- Setting a high standard for you and the team by writing clean, maintainable code and participating
+  in code reviews.
+- Mentoring junior engineers and sharing your knowledge to help the team grow stronger.
+
+About the team
+
+Our team's mission is to make the Amazon Deals experience more dynamic, personalized, and efficient
+through intelligent automation. To achieve our vision, we:
+
+- Build and operate the core services that allow AI agents to access critical data like pricing and
+  inventory to construct valid and compelling promotions.
+- Own the customer-facing features and deep instrumentation that allow us to A/B test different
+  agent-driven strategies and measure customer engagement.
+- Ensure every feature we build creates a data flywheel, where customer interactions are used as a
+  signal to improve the intelligence of our automation systems.
+- Work directly with our internal business teams to automate their most time-consuming tasks,
+  freeing them to focus on curating higher-quality deals for customers.
+- Deliver a best-in-class customer experience by building fast, reliable, and intuitive features
+  that help customers discover the best deals Amazon has to offer.
+
+**BASIC QUALIFICATIONS**
+- 3+ years of non-internship professional software development experience
+- 2+ years of non-internship design or architecture (design patterns, reliability and scaling) of
+  new and existing systems experience
+- Experience programming with at least one software programming language
+
+**PREFERRED QUALIFICATIONS**
+- 3+ years of full software development life cycle, including coding standards, code reviews, source
+  control management, build processes, testing, and operations experience
+- Bachelor's degree in computer science or equivalent
+
+Amazon is an equal opportunity employer and does not discriminate on the basis of protected veteran
+status, disability, or other legally protected status.
+
+Our inclusive culture empowers Amazonians to deliver the best results for our customers. If you have
+a disability and need a workplace accommodation or adjustment during the application and hiring
+process, including support for the interview or onboarding process, please visit
+https://amazon.jobs/content/en/how-we-hire/accommodations for more information. If the
+country/region you’re applying in isn’t listed, please contact your Recruiting Partner.
+
+The base salary for this position ranges from $114,800/year up to $191,800/year. Salary is based on
+a number of factors and may vary depending on job-related knowledge, skills, and experience. Amazon
+is a total compensation company. Dependent on the position offered, equity, sign-on payments, and
+other forms of compensation may be provided as part of a total compensation package, in addition to
+a full range of medical, financial, and/or other benefits. Applicants should apply via our internal
+or external career site.
+

--- a/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052303.md
+++ b/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052303.md
@@ -1,0 +1,81 @@
+# Software Engineer II, Agentic Marketing Automation
+
+Job ID: 3052303 | Amazon Development Centre Canada ULC
+URL: https://www.amazon.jobs/en/jobs/3052303/software-engineer-ii-agentic-marketing-automation
+
+**DESCRIPTION**
+
+Are you excited to build the customer-facing experience for Amazon Deals? Do you want to write code
+for highly-visible, scalable systems that serve millions of customers every day? The Deals &
+Promotions team is at the center of Amazon's retail business, and we are on a mission to create a
+world-class deals experience for our customers. We are building the future where AI and automation
+help us discover and present the best offers, and we are looking for passionate engineers to build
+it with us.
+
+As a an SDE on this team, you will be a key contributor to our most critical projects. You will own
+the design, implementation, and deployment of features and services that shape the Amazon Deals
+experience. This is an end-to-end role where you will work on everything from the customer-facing
+user interface to the backend automation services that integrate with AI Agents to bring our
+promotions to life. We are looking for a customer-focused engineer who is comfortable working
+through ambiguity, has a passion for building high-quality, robust software, and enjoys the
+challenge of working at a massive scale.
+
+A day in the life
+
+As a an SDE II, you will work with your team to invent, design, and build software that is used by
+millions of people. You will have a direct impact on our customers and the business. You will be
+responsible for:
+
+- Designing, implementing, testing, and deploying scalable, low-latency services and features for
+  our deals and promotions platform.
+- Working closely with product managers, UX designers, and other engineers to translate customer and
+  business requirements into robust technical solutions.
+- Contributing to the operational excellence of the team's services, participating in on-call
+  rotations, and improving system performance and reliability.
+- Setting a high standard for you and the team by writing clean, maintainable code and participating
+  in code reviews.
+- Mentoring junior engineers and sharing your knowledge to help the team grow stronger.
+
+About the team
+
+Our team's mission is to make the Amazon Deals experience more dynamic, personalized, and efficient
+through intelligent automation. To achieve our vision, we:
+
+- Build and operate the core services that allow AI agents to access critical data like pricing and
+  inventory to construct valid and compelling promotions.
+- Own the customer-facing features and deep instrumentation that allow us to A/B test different
+  agent-driven strategies and measure customer engagement.
+- Ensure every feature we build creates a data flywheel, where customer interactions are used as a
+  signal to improve the intelligence of our automation systems.
+- Work directly with our internal business teams to automate their most time-consuming tasks,
+  freeing them to focus on curating higher-quality deals for customers.
+- Deliver a best-in-class customer experience by building fast, reliable, and intuitive features
+  that help customers discover the best deals Amazon has to offer.
+
+**BASIC QUALIFICATIONS**
+- 3+ years of non-internship professional software development experience
+- 2+ years of non-internship design or architecture (design patterns, reliability and scaling) of
+  new and existing systems experience
+- Experience programming with at least one software programming language
+
+**PREFERRED QUALIFICATIONS**
+- 3+ years of full software development life cycle, including coding standards, code reviews, source
+  control management, build processes, testing, and operations experience
+- Bachelor's degree in computer science or equivalent
+
+Amazon is an equal opportunity employer and does not discriminate on the basis of protected veteran
+status, disability, or other legally protected status.
+
+Our inclusive culture empowers Amazonians to deliver the best results for our customers. If you have
+a disability and need a workplace accommodation or adjustment during the application and hiring
+process, including support for the interview or onboarding process, please visit
+https://amazon.jobs/content/en/how-we-hire/accommodations for more information. If the
+country/region you’re applying in isn’t listed, please contact your Recruiting Partner.
+
+The base salary for this position ranges from $114,800/year up to $191,800/year. Salary is based on
+a number of factors and may vary depending on job-related knowledge, skills, and experience. Amazon
+is a total compensation company. Dependent on the position offered, equity, sign-on payments, and
+other forms of compensation may be provided as part of a total compensation package, in addition to
+a full range of medical, financial, and/or other benefits. Applicants should apply via our internal
+or external career site.
+

--- a/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052309.md
+++ b/job_descriptions/software_engineer_ii_agentic_marketing_automation_3052309.md
@@ -1,0 +1,81 @@
+# Software Engineer II, Agentic Marketing Automation
+
+Job ID: 3052309 | Amazon Development Centre Canada ULC
+URL: https://www.amazon.jobs/en/jobs/3052309/software-engineer-ii-agentic-marketing-automation
+
+**DESCRIPTION**
+
+Are you excited to build the customer-facing experience for Amazon Deals? Do you want to write code
+for highly-visible, scalable systems that serve millions of customers every day? The Deals &
+Promotions team is at the center of Amazon's retail business, and we are on a mission to create a
+world-class deals experience for our customers. We are building the future where AI and automation
+help us discover and present the best offers, and we are looking for passionate engineers to build
+it with us.
+
+As a an SDE on this team, you will be a key contributor to our most critical projects. You will own
+the design, implementation, and deployment of features and services that shape the Amazon Deals
+experience. This is an end-to-end role where you will work on everything from the customer-facing
+user interface to the backend automation services that integrate with AI Agents to bring our
+promotions to life. We are looking for a customer-focused engineer who is comfortable working
+through ambiguity, has a passion for building high-quality, robust software, and enjoys the
+challenge of working at a massive scale.
+
+A day in the life
+
+As a an SDE II, you will work with your team to invent, design, and build software that is used by
+millions of people. You will have a direct impact on our customers and the business. You will be
+responsible for:
+
+- Designing, implementing, testing, and deploying scalable, low-latency services and features for
+  our deals and promotions platform.
+- Working closely with product managers, UX designers, and other engineers to translate customer and
+  business requirements into robust technical solutions.
+- Contributing to the operational excellence of the team's services, participating in on-call
+  rotations, and improving system performance and reliability.
+- Setting a high standard for you and the team by writing clean, maintainable code and participating
+  in code reviews.
+- Mentoring junior engineers and sharing your knowledge to help the team grow stronger.
+
+About the team
+
+Our team's mission is to make the Amazon Deals experience more dynamic, personalized, and efficient
+through intelligent automation. To achieve our vision, we:
+
+- Build and operate the core services that allow AI agents to access critical data like pricing and
+  inventory to construct valid and compelling promotions.
+- Own the customer-facing features and deep instrumentation that allow us to A/B test different
+  agent-driven strategies and measure customer engagement.
+- Ensure every feature we build creates a data flywheel, where customer interactions are used as a
+  signal to improve the intelligence of our automation systems.
+- Work directly with our internal business teams to automate their most time-consuming tasks,
+  freeing them to focus on curating higher-quality deals for customers.
+- Deliver a best-in-class customer experience by building fast, reliable, and intuitive features
+  that help customers discover the best deals Amazon has to offer.
+
+**BASIC QUALIFICATIONS**
+- 3+ years of non-internship professional software development experience
+- 2+ years of non-internship design or architecture (design patterns, reliability and scaling) of
+  new and existing systems experience
+- Experience programming with at least one software programming language
+
+**PREFERRED QUALIFICATIONS**
+- 3+ years of full software development life cycle, including coding standards, code reviews, source
+  control management, build processes, testing, and operations experience
+- Bachelor's degree in computer science or equivalent
+
+Amazon is an equal opportunity employer and does not discriminate on the basis of protected veteran
+status, disability, or other legally protected status.
+
+Our inclusive culture empowers Amazonians to deliver the best results for our customers. If you have
+a disability and need a workplace accommodation or adjustment during the application and hiring
+process, including support for the interview or onboarding process, please visit
+https://amazon.jobs/content/en/how-we-hire/accommodations for more information. If the
+country/region you’re applying in isn’t listed, please contact your Recruiting Partner.
+
+The base salary for this position ranges from $114,800/year up to $191,800/year. Salary is based on
+a number of factors and may vary depending on job-related knowledge, skills, and experience. Amazon
+is a total compensation company. Dependent on the position offered, equity, sign-on payments, and
+other forms of compensation may be provided as part of a total compensation package, in addition to
+a full range of medical, financial, and/or other benefits. Applicants should apply via our internal
+or external career site.
+


### PR DESCRIPTION
## Summary
- ensure each Amazon Software Engineer II, Agentic Marketing Automation job posting is copied verbatim
- add direct Amazon job URLs for all four Vancouver postings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bad3e9d9648322beabd6e546c51b7f